### PR TITLE
Convert relative document paths to absolute paths

### DIFF
--- a/council_crawler/council_crawler/spiders/ca_belmont.py
+++ b/council_crawler/council_crawler/spiders/ca_belmont.py
@@ -1,5 +1,6 @@
 import datetime
 from urllib.parse import urljoin
+from scrapy.utils.response import get_base_url
 
 import scrapy
 
@@ -19,13 +20,13 @@ class Belmont(scrapy.spiders.CrawlSpider):
             yield scrapy.Request(url=url, callback=self.parse_archive)
 
     def parse_archive(self, response):
+        archive_base_url = get_base_url(response)
 
         def get_agenda_url(relative_urls):
             full_url = []
             if relative_urls:
                 for url in relative_urls:
-                    base_url = 'http://belmont.gov'
-                    url = urljoin(base_url, url)
+                    url = urljoin(archive_base_url, url)
                     full_url.append(url)
                 return full_url
             else:
@@ -51,6 +52,9 @@ class Belmont(scrapy.spiders.CrawlSpider):
 
             documents = []
             if agenda_url is not None:
+                # If path to agenda is relative, complete it with the base url
+                if archive_base_url not in agenda_url:
+                    agenda_url = urljoin(archive_base_url, agenda_url)
                 agenda_doc = {
                     'url': agenda_url,
                     'url_hash': url_to_md5(agenda_url),
@@ -59,6 +63,9 @@ class Belmont(scrapy.spiders.CrawlSpider):
                 documents.append(agenda_doc)
 
             if event_minutes_url is not None:
+                # If path to minutes is relative, complete it with the base url
+                if BASE_URL not in event_minutes_url:
+                    event_minutes_url = urljoin(archive_base_url, event_minutes_url)
                 minutes_doc = {
                     'url': event_minutes_url,
                     'url_hash': url_to_md5(event_minutes_url),


### PR DESCRIPTION
Addresses issue #13 

-> Add import of `get_base_url` from `scrapy.utils.response`
-> Use `get_base_url` and `urljoin` to check and convert all agenda and minutes URLs